### PR TITLE
fix(flux): prevent side effects in getValeur method

### DIFF
--- a/models/possessions/Flux.js
+++ b/models/possessions/Flux.js
@@ -19,30 +19,28 @@ export default class Flux extends Possession {
 
 
   getValeur(date) {
-
     const nombreDeMois = (debut, dateEvaluation, jourJ) => {
-        
-        let compteur = 0;
-    
-        if (debut.getDate() < jourJ) {
-            compteur++;
-        }
-        
-        if (dateEvaluation.getDate() >= jourJ && !(debut.getFullYear() === dateEvaluation.getFullYear() && debut.getMonth() === dateEvaluation.getMonth())) {
-            compteur++;
-        }
-        
-        let totalMois = (dateEvaluation.getFullYear() - debut.getFullYear()) * 12 + (dateEvaluation.getMonth() - debut.getMonth()) - 1;
-    
-        compteur += Math.max(0, totalMois);
-    
-        return compteur;
-    }
+      let compteur = 0;
 
-    // calcul montant total
+      if (debut.getDate() < jourJ) {
+        compteur++;
+      }
 
-    this.valeur += nombreDeMois(this.dateDebut, date, this.jour) * this.valeurConstante;
+      if (dateEvaluation.getDate() >= jourJ && !(debut.getFullYear() === dateEvaluation.getFullYear() && debut.getMonth() === dateEvaluation.getMonth())) {
+        compteur++;
+      }
 
-    return this.valeur;
+      let totalMois = (dateEvaluation.getFullYear() - debut.getFullYear()) * 12 + (dateEvaluation.getMonth() - debut.getMonth()) - 1;
+
+      compteur += Math.max(0, totalMois);
+
+      return compteur;
+    };
+
+    // Calculer le montant total sans modifier this.valeur
+    const totalMois = nombreDeMois(this.dateDebut, date, this.jour);
+    const montantTotal = totalMois * this.valeurConstante;
+
+    return montantTotal;
   }
 }

--- a/test/patrimone.test.js
+++ b/test/patrimone.test.js
@@ -133,3 +133,20 @@ describe("Test about possession increasing ration :", () => {
         assert.equal(savingsAccount.getValeur(new Date("2025-3-3")), 220_000)
     })
 })
+
+describe("A test for calculating the total value of all possessions using Patrimoine.getValeur", ()=>{
+  it("it should return 3855128.7671232875", ()=>{
+    const Ilo = new Personne("Ilo");
+    const ordinateur = new Possession(Ilo,"ordinateur",2_000_000,new Date("2021-05-10"),null,10);
+    const compteEpargne = new Argent(Ilo,"compte epargne",20_000,new Date("2023-04-09"),null,60,"2023-06-01",TYPE_ARGENT.Epargne);
+    const salary = new Flux(Ilo,"Salaire",600_000,new Date("2024-3-3"),null,0,15);
+    const spending = new Flux(Ilo,"Depense",-100_000,new Date("2024-3-3"),null,0,1);
+
+    const possessions = [ordinateur, compteEpargne, salary, spending];
+    const patrimoine = new Patrimoine(Ilo, possessions)
+
+    const date = new Date("2024-8-8");
+    const result = ordinateur.getValeur(date) + compteEpargne.getValeur(date) + salary.getValeur(date) + spending.getValeur(date)
+    assert.equal(patrimoine.getValeur(date), result)
+  })
+})


### PR DESCRIPTION
Réorganisation de la méthode getValeur dans la classe Flux pour éviter de modifier l'état interne de this.valeur lors du calcul. Cela garantit que plusieurs appels à getValeur n'interfèrent pas les uns avec les autres pour avoir un comportement cohérent, 

Voici ce qui arrivait avant 
```javascript
const possessions = [ordinateur, compteEpargne, salary, spending];
const patrimoine = new Patrimoine(Ilo, possessions);

const date = new Date("2024-8-8");
const sum = ordinateur.getValeur(date) + compteEpargne.getValeur(date) + salary.getValeur(date) + spending.getValeur(date);

console.log(patrimoine.getValeur(date))
console.log(sum)
```
patrimoine.getValeur donnait un resultat different de sum
